### PR TITLE
Braintree ACH + CC form compatibility added with custom toggle option

### DIFF
--- a/assets/js/angelleye-braintree-ach-cc.js
+++ b/assets/js/angelleye-braintree-ach-cc.js
@@ -41,7 +41,7 @@ jQuery(document).ready(function ($) {
         var selectedradio = form.find('.gform_payment_method_options input[type=radio]:checked').val();
 
         var check_if_ach_form = form.find('.ginput_ach_form_container');
-        if(check_if_ach_form.length && (typeof selectedradio ==='undefined' || selectedradio === 'braintree_ach')){
+        if(check_if_ach_form.length && (selectedradio === 'braintree_ach' || check_if_ach_form.closest('.gfield').css('display')!=='none')){
             if(form.find('.ginput_container_address').length==0){
                 alert('ACH payment requires billing address fields, so please include Billing Address field in your Gravity form.');
                 return;

--- a/includes/angelleye-gravity-braintree-helper.php
+++ b/includes/angelleye-gravity-braintree-helper.php
@@ -81,28 +81,26 @@ function getAngelleyeBraintreePaymentMethod($form){
  * This is to setup default values for Custom Toggle and ACH form fields in admin panel
  */
 
-add_action( 'gform_loaded', function (){
-	add_action( 'gform_editor_js_set_default_values', 'gravityFormSetDefaultValueOnDropin' );
-	function gravityFormSetDefaultValueOnDropin() {
-		?>
-		case "braintree_ach" :
-            if (!field.label)
-            field.label = <?php echo json_encode( esc_html__( 'Pay through your Bank Account', 'gravity-forms-braintree' ) ); ?>;
-            var accNumber, accType, routingNumber, accName;
+add_action( 'gform_editor_js_set_default_values', 'gravityFormSetDefaultValueOnDropin' );
+function gravityFormSetDefaultValueOnDropin() {
+    ?>
+    case "braintree_ach" :
+        if (!field.label)
+        field.label = <?php echo json_encode( esc_html__( 'Pay through your Bank Account', 'gravity-forms-braintree' ) ); ?>;
+        var accNumber, accType, routingNumber, accName;
 
-            accNumber = new Input(field.id + ".1", <?php echo json_encode( gf_apply_filters( array( 'gform_account_number', rgget( 'id' ) ), esc_html__( 'Account Number', 'gravity-forms-braintree' ), rgget( 'id' ) ) ); ?>);
-            accType = new Input(field.id + ".2", <?php echo json_encode( gf_apply_filters( array( 'gform_account_type', rgget( 'id' ) ), esc_html__( 'Account Type', 'gravity-forms-braintree' ), rgget( 'id' ) ) ); ?>);
-            routingNumber = new Input(field.id + ".3", <?php echo json_encode( gf_apply_filters( array( 'gform_routing_number', rgget( 'id' ) ), esc_html__( 'Routing Number', 'gravity-forms-braintree' ), rgget( 'id' ) ) ); ?>);
-            accName = new Input(field.id + ".4", <?php echo json_encode( gf_apply_filters( array( 'gform_account_name', rgget( 'id' ) ), esc_html__( 'Account Holder Name', 'gravity-forms-braintree' ), rgget( 'id' ) ) ); ?>);
-            field.inputs = [accNumber, accType, routingNumber, accName];
-		    break;
-		case "braintree_ach_cc_toggle":
-            if (!field.label)
-            field.label = <?php echo json_encode( esc_html__( 'Select a Payment Method', 'gravity-forms-braintree' ) ); ?>;
-            var paymentMethodToggle;
-            paymentMethodToggle = new Input(field.id + ".1", <?php echo json_encode( gf_apply_filters( array( 'gform_payment_method_selected', rgget( 'id' ) ), esc_html__( 'Payment Method Toggle', 'gravity-forms-braintree' ), rgget( 'id' ) ) ); ?>);
-            field.inputs = [paymentMethodToggle];
-		    break;
-		<?php
-	}
-} );
+        accNumber = new Input(field.id + ".1", <?php echo json_encode( gf_apply_filters( array( 'gform_account_number', rgget( 'id' ) ), esc_html__( 'Account Number', 'gravity-forms-braintree' ), rgget( 'id' ) ) ); ?>);
+        accType = new Input(field.id + ".2", <?php echo json_encode( gf_apply_filters( array( 'gform_account_type', rgget( 'id' ) ), esc_html__( 'Account Type', 'gravity-forms-braintree' ), rgget( 'id' ) ) ); ?>);
+        routingNumber = new Input(field.id + ".3", <?php echo json_encode( gf_apply_filters( array( 'gform_routing_number', rgget( 'id' ) ), esc_html__( 'Routing Number', 'gravity-forms-braintree' ), rgget( 'id' ) ) ); ?>);
+        accName = new Input(field.id + ".4", <?php echo json_encode( gf_apply_filters( array( 'gform_account_name', rgget( 'id' ) ), esc_html__( 'Account Holder Name', 'gravity-forms-braintree' ), rgget( 'id' ) ) ); ?>);
+        field.inputs = [accNumber, accType, routingNumber, accName];
+        break;
+    case "braintree_ach_cc_toggle":
+        if (!field.label)
+        field.label = <?php echo json_encode( esc_html__( 'Select a Payment Method', 'gravity-forms-braintree' ) ); ?>;
+        var paymentMethodToggle;
+        paymentMethodToggle = new Input(field.id + ".1", <?php echo json_encode( gf_apply_filters( array( 'gform_payment_method_selected', rgget( 'id' ) ), esc_html__( 'Payment Method Toggle', 'gravity-forms-braintree' ), rgget( 'id' ) ) ); ?>);
+        field.inputs = [paymentMethodToggle];
+        break;
+    <?php
+}

--- a/includes/angelleye-gravity-braintree-helper.php
+++ b/includes/angelleye-gravity-braintree-helper.php
@@ -18,6 +18,65 @@ function getAngelleyeBraintreePaymentFields($form){
 	return $response;
 }
 
+function getAngelleyeBraintreePaymentMethod($form){
+	$selected_method = '';
+    $response = getAngelleyeBraintreePaymentFields($form);
+
+    //This means customer is using our toggle button
+    if($response['braintree_ach_cc_toggle'] !== false){
+	    $selected_method = rgpost( 'input_' . $response['braintree_ach_cc_toggle']->id . '_1' );
+    }else {
+        if($response['creditcard']!==false){
+            if(isset($response['creditcard']['conditionalLogic']) && is_array($response['creditcard']['conditionalLogic']) && count($response['creditcard']['conditionalLogic'])){
+                $conditionalLogic =  $response['creditcard']['conditionalLogic'];
+                if($conditionalLogic['actionType'] == 'show'){
+                    foreach ( $conditionalLogic['rules'] as $rule ) {
+                        if($rule['operator'] == 'is') {
+                            $fieldId = $rule['fieldId'];
+                            $isValue = $rule['value'];
+                            $selected_radio_value = rgpost( 'input_' . $fieldId );
+
+                            if($selected_radio_value == $isValue){
+                                $selected_method = 'creditcard';
+                                break;
+                            }
+                        }
+                    }
+                }
+
+            }
+        }
+
+        if($selected_method=='' && $response['braintree_ach'] !== false){
+	        if(isset($response['braintree_ach']['conditionalLogic']) && is_array($response['braintree_ach']['conditionalLogic']) && count($response['braintree_ach']['conditionalLogic'])){
+                $conditionalLogic =  $response['braintree_ach']['conditionalLogic'];
+                if($conditionalLogic['actionType'] == 'show'){
+                    foreach ( $conditionalLogic['rules'] as $rule ) {
+                        if($rule['operator'] == 'is') {
+                            $fieldId = $rule['fieldId'];
+                            $isValue = $rule['value'];
+                            $selected_radio_value = rgpost( 'input_' . $fieldId );
+                            if($selected_radio_value == $isValue){
+                                $selected_method = 'braintree_ach';
+                                break;
+                            }
+                        }
+                    }
+                }
+	        }
+        }
+
+        if($selected_method == '' && $response['creditcard']!==false){
+            $selected_method = 'creditcard';
+        }else if($selected_method == '' && $response['braintree_ach']!==false){
+	        $selected_method = 'braintree_ach';
+        }
+
+    }
+    return $selected_method;
+}
+
+
 /**
  * This is to setup default values for Custom Toggle and ACH form fields in admin panel
  */

--- a/includes/class-angelleye-gravity-braintree-ach-field.php
+++ b/includes/class-angelleye-gravity-braintree-ach-field.php
@@ -4,6 +4,7 @@ defined('ABSPATH') or die('Direct access not allowed');
 
 class Angelleye_Gravity_Braintree_ACH_Field extends GF_Field {
 
+	private $selected_payment_method = '';
 	/**
 	 * @var string $type The field type.
 	 */
@@ -260,6 +261,11 @@ onkeypress='if( event.keyCode == 13 ){ if(window[\"gf_submitting_{$form['id']}\"
 	 */
 	function customCCValidation($validation_result){
 		$form = $validation_result['form'];
+		$this->selected_payment_method = getAngelleyeBraintreePaymentMethod($form);
+
+		if($this->selected_payment_method !== 'braintree_ach')
+			return $validation_result;
+
 		$failed_validation = 0;
 		if(isset($form['fields'])) {
 
@@ -300,13 +306,9 @@ onkeypress='if( event.keyCode == 13 ){ if(window[\"gf_submitting_{$form['id']}\"
 	public function validate( $value, $form ) {
 
 		//check if toggle field exist
-		$selected_payment_method = 'braintree_ach';
-		$response = getAngelleyeBraintreePaymentFields($form);
-		if($response['braintree_ach_cc_toggle']!==false){
-			$selected_payment_method = rgpost( 'input_' . $response['braintree_ach_cc_toggle']->id . '_1' );
-		}
+		$this->selected_payment_method = getAngelleyeBraintreePaymentMethod($form);
 
-		if($selected_payment_method!=='braintree_ach') {
+		if($this->selected_payment_method!=='braintree_ach') {
 			return;
 		}
 
@@ -347,10 +349,10 @@ onkeypress='if( event.keyCode == 13 ){ if(window[\"gf_submitting_{$form['id']}\"
 	public function get_value_submission( $field_values, $get_from_post_global_var = true ) {
 
 		if ( $get_from_post_global_var ) {
-			$value[ $this->id . '.1' ] = $this->get_input_value_submission( 'input_' . $this->id . '_1', rgar( $this->inputs[0], 'name' ), $field_values, true );
-			$value[ $this->id . '.2' ] = $this->get_input_value_submission( 'input_' . $this->id . '_2', rgar( $this->inputs[1], 'name' ), $field_values, true );
-			$value[ $this->id . '.3' ] = $this->get_input_value_submission( 'input_' . $this->id . '_3', rgar( $this->inputs[2], 'name' ), $field_values, true );
-			$value[ $this->id . '.4' ] = $this->get_input_value_submission( 'input_' . $this->id . '_4', rgar( $this->inputs[3], 'name' ), $field_values, true );
+			$value[ $this->id . '.1' ] = $this->get_input_value_submission( 'input_' . $this->id . '_1', rgar( @$this->inputs[0], 'name' ), $field_values, true );
+			$value[ $this->id . '.2' ] = $this->get_input_value_submission( 'input_' . $this->id . '_2', rgar( @$this->inputs[1], 'name' ), $field_values, true );
+			$value[ $this->id . '.3' ] = $this->get_input_value_submission( 'input_' . $this->id . '_3', rgar( @$this->inputs[2], 'name' ), $field_values, true );
+			$value[ $this->id . '.4' ] = $this->get_input_value_submission( 'input_' . $this->id . '_4', rgar( @$this->inputs[3], 'name' ), $field_values, true );
 		} else {
 			$value = $this->get_input_value_submission( 'input_' . $this->id, $this->inputName, $field_values, $get_from_post_global_var );
 		}

--- a/includes/class-angelleye-gravity-braintree-ach-field.php
+++ b/includes/class-angelleye-gravity-braintree-ach-field.php
@@ -436,8 +436,10 @@ onkeypress='if( event.keyCode == 13 ){ if(window[\"gf_submitting_{$form['id']}\"
 			$account_type = trim( rgget( $this->id . '.2', $value ) );
 			$routing_number = trim( rgget( $this->id . '.3', $value ) );
 			$account_holder_name   = trim( rgget( $this->id . '.4', $value ) );
+			if($account_number=='')
+				return 'N/A';
 			if($format=='html')
-			return "<b>Account Number: </b> $account_number <br/>
+				return "<b>Account Number: </b> $account_number <br/>
 <b>Account Type: </b> ".($account_type=='s'?'Savings':'Checking')." <br/>
 <b>Routing Number: </b> $routing_number <br/>
 <b>Account Holder: </b> $account_holder_name <br/>";


### PR DESCRIPTION
Added the automatic payment method detection technique based on the  Braintree ACH + CC field conditions set to work with custom radio options