### PR TITLE
Clarify Braintree feed list message & frontend when form has no payment field

### DIFF
--- a/lib/class.plugify-gform-braintree.php
+++ b/lib/class.plugify-gform-braintree.php
@@ -64,13 +64,56 @@ final class Plugify_GForm_Braintree extends GFPaymentAddOn {
     }
 
     /**
-     * Override default message for Gravity Form Braintree Feeds
+     * Message shown on the Braintree feed list when the form has no Braintree payment field.
+     *
+     * Gravity Forms' payment framework hides the entire feed list (and blocks feed creation)
+     * until the form contains a supported payment field. The default wording ("...before
+     * creating a feed") is confusing when feeds already exist, because it reads as if the
+     * feeds are gone. This message instead reassures the user that their saved feeds are
+     * intact, explains why they are hidden, and links straight to the form editor.
+     *
      * @return string
      */
     public function requires_credit_card_message() {
-        $url = add_query_arg(array('view' => null, 'subview' => null));
 
-        return sprintf(esc_html__("You must add a Credit Card/ACH Payment field to your form before creating a feed. Let's go %sadd one%s!", 'gravityforms'), "<a href='" . esc_url($url) . "'>", '</a>');
+        $form    = $this->get_current_form();
+        $form_id = is_array($form) ? rgar($form, 'id') : 0;
+
+        // Link directly to the form editor so the user can add the field.
+        $add_field_url = $form_id
+            ? admin_url('admin.php?page=gf_edit_forms&id=' . $form_id)
+            : add_query_arg(array('view' => null, 'subview' => null));
+
+        $feed_count = $form_id ? count($this->get_feeds($form_id)) : 0;
+
+        if ($feed_count > 0) {
+            $intro = sprintf(
+                _n(
+                    'You have %d saved Braintree feed, but it can\'t be shown or processed until this form has a Braintree payment field.',
+                    'You have %d saved Braintree feeds, but they can\'t be shown or processed until this form has a Braintree payment field.',
+                    $feed_count,
+                    'angelleye-gravity-forms-braintree'
+                ),
+                $feed_count
+            );
+        } else {
+            $intro = esc_html__("This form doesn't have a Braintree payment field yet, so no feeds can be created or processed.", 'angelleye-gravity-forms-braintree');
+        }
+
+        $instructions = esc_html__('Add a Braintree Credit Card or Braintree ACH field to this form, then return to this page to view and manage your feeds.', 'angelleye-gravity-forms-braintree');
+        $button       = esc_html__('Edit form to add a field', 'angelleye-gravity-forms-braintree');
+
+        return sprintf(
+            '<div style="padding:12px 0;line-height:1.6;">'
+            . '<p style="margin:0 0 6px;font-weight:600;font-size:13px;">%1$s</p>'
+            . '<p style="margin:0 0 12px;">%2$s</p>'
+            . '<a class="button button-primary" href="%3$s">%4$s</a>'
+            . '</div>',
+            esc_html($intro),
+            $instructions,
+            esc_url($add_field_url),
+            $button
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary

Two related admin/front-end UX fixes for the Braintree feed and payment field rendering. Both address cases where the plugin previously showed a blank or confusing state, leaving users unsure what to do.

1. **Feed list:** Clarify the message shown when a form has no Braintree payment field.
2. **Front-end gateway:** Show a proper notice when a form has no amount/pricing field, instead of rendering an unusable payment UI.

## 1. Clarify Braintree feed list message when form has no payment field

### Problem
Gravity Forms' payment framework hides the **entire feed list** (via `feed_list_message()`) until the form contains a supported payment field. When feeds already existed, the default message — *"You must add a Credit Card/ACH Payment field to your form before creating a feed"* — read as if the saved feeds were **gone**, so the page looked blank/broken even though the feeds were intact in the database.

### Fix
Rewrote `requires_credit_card_message()` in `lib/class.plugify-gform-braintree.php` to:
- Reassure the user their saved feeds are intact (shows the actual feed count, with correct singular/plural).
- Explain *why* the list is hidden — the form lacks a Braintree payment field.
- Provide a primary **"Edit form to add a field"** button linking directly to that form's editor (replacing the old inline link that rendered with an empty `href`).
- Fall back to a clear "no feeds yet" message when the form genuinely has none.

### Notes
- Behavior is unchanged — feeds still require a Braintree CC/ACH field to display, per standard GF payment add-on behavior. Only the **message** is improved.

## 2. Show clear notice when Braintree gateway has no amount field

### Problem
The Braintree credit card (Drop-in) and ACH fields rendered a live payment UI even when the form had **no pricing field**, leaving users with a gateway that has no amount to charge.

### Fix
Added a guard that detects when a form has no amount source (no Product field **and** no Total field) and renders an informative notice in place of the payment UI:
- **Admins** who can edit forms get an actionable message linking straight to the form editor to add a Product field.
- **Visitors** get a generic *"contact the site administrator"* message, so no configuration details are leaked.

Implementation details:
- For the **credit card field**, the check runs **before** the client-token request, so the Braintree API call is skipped when there is nothing to charge (small perf win).
- The **ACH field** is guarded the same way, except in the form editor / entry-detail views.

New helpers in `includes/angelleye-gravity-braintree-helper.php`:
- `angelleye_braintree_has_amount_source()`
- `angelleye_braintree_form_has_amount_field()`
- `angelleye_braintree_missing_amount_field_notice()`

## Files changed
- `lib/class.plugify-gform-braintree.php` — improved feed-list message
- `includes/angelleye-gravity-braintree-helper.php` — amount-source helpers + notice builder
- `includes/class-angelleye-gravity-braintree-creditcard.php` — missing-amount guard (before client token)
- `includes/class-angelleye-gravity-braintree-ach-field.php` — missing-amount guard

## Testing
- All changed files pass `php -l`.
- Verified via WordPress-bootstrapped probes:
  - Feed-list message renders with correct feed count (singular/plural) and a working editor link.
  - `has_amount_source()` returns `false` for empty, `true` for product-only / total-only.
  - Missing-amount notice renders the admin (with link) and visitor (generic) variants correctly.
  - Gateway renders normally once the form has a pricing field (guard passes through).
